### PR TITLE
Fix error when running with PHP5

### DIFF
--- a/pg2mysql.inc.php
+++ b/pg2mysql.inc.php
@@ -126,11 +126,11 @@ function pg2mysql_large($infilename,$outfilename) {
 
 }
 
-function pg2mysql(&$input, $header=true)
+function pg2mysql($input, $header=true)
 {
 	global $config;
 
-	if(is_array(&$input)) {
+	if(is_array($input)) {
 		$lines=$input;
 	} else {
 		$lines=split("\n",$input);


### PR DESCRIPTION
Fix error when running with PHP5: 'PHP Fatal error:  Call-time pass-by-reference has been removed in pg2mysql.inc.php on line 133'

Everything else works fine for me.