### PR TITLE
Allow providing key type for autoincrement fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,23 @@
     
 1. `mysql dbname < mysqlfile.sql`
   
+  
+## Additional behaviors
+
+### Auto-increment key type
+
+The key type created for autoincrement fields is configureable via the `PG2MYSQL_AUTOINCREMENT_KEY_TYPE` environment variable.
+
+The default is `PRIMARY KEY`. A simple `KEY` can be used to circumvent the fact that MySQL does not support multiple primary keys.
+
+This option is particularly useful for converting dumps that have primary keys on the auto_increment field already defined as `ALTER TABLE` statements.
+
+Usage example:
+```
+export PG2MYSQL_AUTOINCREMENT_KEY_TYPE=KEY
+php pg2mysql_cli.php <options ...>
+```
+
 ## Web usage
 
 To use, simply unzip into your website somewhere, and point your browser at `pg2mysql.php`

--- a/pg2mysql.inc.php
+++ b/pg2mysql.inc.php
@@ -29,6 +29,7 @@ define ('COPYRIGHT',"Lightbox Technologies Inc. http://www.lightbox.ca");
 
 //this is the default, it can be overridden here, or specified as the third parameter on the command line
 $config['engine']="InnoDB";
+$config['autoincrement_key_type'] = getenv("PG2MYSQL_AUTOINCREMENT_KEY_TYPE") ? getenv("PG2MYSQL_AUTOINCREMENT_KEY_TYPE") : "PRIMARY KEY";
 
 // Timezone to use
 date_default_timezone_set('UTC');
@@ -235,7 +236,7 @@ function pg2mysql($input, $header=true)
 
 			if(strstr($line,"auto_increment")) {
 				$field=getfieldname($line);
-				$tbl_extra.=", PRIMARY KEY(`$field`)\n";
+				$tbl_extra.=", " . $config['autoincrement_key_type'] . "(`$field`)\n";
 			}
 
 			$specialfields=array("repeat","status","type","call", "key", "regexp");


### PR DESCRIPTION
Currently, a new primary key is created for every autoincrement field. This
can be a problem in dumps where the primary key was already exported. It causes
"duplicate primary key" statements when importing into MySQL.

This commit introduces a configureable behavior. The autoincrement key type is
now configureable via the PG2MYSQL_AUTOINCREMENT_KEY_TYPE environment variable.