### PR TITLE
Strip timezone information from date fields

### DIFF
--- a/pg2mysql.inc.php
+++ b/pg2mysql.inc.php
@@ -226,6 +226,9 @@ function pg2mysql($input, $header=true)
 			$line=str_replace(" timestamp with time zone"," timestamp",$line);
 			$line=str_replace(" timestamp without time zone"," timestamp",$line);
 
+			// Strip unsupported timezone information in date fields
+			$line=preg_replace("/ date DEFAULT '(.*)\+.*'/",' date DEFAULT \'${1}\'',$line);
+
 			//time
 			$line=str_replace(" time with time zone"," time",$line);
 			$line=str_replace(" time without time zone"," time",$line);

--- a/pg2mysql.inc.php
+++ b/pg2mysql.inc.php
@@ -227,7 +227,7 @@ function pg2mysql($input, $header=true)
 			$line=str_replace(" timestamp without time zone"," timestamp",$line);
 
 			// Strip unsupported timezone information in date fields
-			$line=preg_replace("/ date DEFAULT '(.*)\+.*'/",' date DEFAULT \'${1}\'',$line);
+			$line=preg_replace("/ date DEFAULT '(.*)(\+|\-).*'/",' date DEFAULT \'${1}\'',$line);
 
 			//time
 			$line=str_replace(" time with time zone"," time",$line);


### PR DESCRIPTION
Currently, timezone information for default values on date fields is left
as-is. More often than not, this default value contains timezone information.

This commit strips the timezone information from the default value because
it is not possible to provide timezone information in a MySQL date field.
Proper conversion is, as always with MySQL, left to the application.