### PR TITLE
Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,16 @@ export PG2MYSQL_AUTOINCREMENT_KEY_TYPE=KEY
 php pg2mysql_cli.php <options ...>
 ```
 
+### Ignoring INDEX
+
+Tables indexes are converted except if the environment variable PG2MYSQL_IGNORE_INDEX is set to a truthy value.
+
+Usage example:
+```
+export PG2MYSQL_IGNORE_INDEX=1
+php pg2mysql_cli.php <options ...>
+``` 
+
 ## Web usage
 
 To use, simply unzip into your website somewhere, and point your browser at `pg2mysql.php`

--- a/pg2mysql.inc.php
+++ b/pg2mysql.inc.php
@@ -220,7 +220,7 @@ function pg2mysql($input, $header=true)
             $line=str_replace("` `text`", "` text", $line); // fix because pg_dump quotes text type for some reason
             if (preg_match("/ character varying\(([0-9]*)\)/", $line, $regs)) {
                 $num=$regs[1];
-                if ($num<=255) {
+                if ($num<=65000) {
                     # Pattern delimniter "/" fails here. Use alternatively "|".
                     $line=preg_replace("| character varying\([0-9]*\)|", " varchar($num)", $line);
                 } else {
@@ -248,7 +248,7 @@ function pg2mysql($input, $header=true)
             $line=preg_replace("/::.*$/", "\n", $line);
             if (preg_match("/character\(([0-9]*)\)/", $line, $regs)) {
                 $num=$regs[1];
-                if ($num<=255) {
+                if ($num<=65000) {
                     $line=preg_replace("/ character\([0-9]*\)/", " varchar($num)", $line);
                 } else {
                     $line=preg_replace("/ character\([0-9]*\)/", " text", $line);

--- a/pg2mysql.inc.php
+++ b/pg2mysql.inc.php
@@ -30,6 +30,7 @@ define('COPYRIGHT', "Lightbox Technologies Inc. http://www.lightbox.ca");
 //this is the default, it can be overridden here, or specified as the third parameter on the command line
 $config['engine']="InnoDB";
 $config['autoincrement_key_type'] = getenv("PG2MYSQL_AUTOINCREMENT_KEY_TYPE") ? getenv("PG2MYSQL_AUTOINCREMENT_KEY_TYPE") : "PRIMARY KEY";
+$config['ignore_index'] = getenv("PG2MYSQL_IGNORE_INDEX");
 
 $tables = array();
 $tables_extra = array();
@@ -373,7 +374,7 @@ function pg2mysql($input, $header=true)
         }
 
         //while we're here, we might as well catch CREATE INDEX as well
-        if (substr($line, 0, 12)=="CREATE INDEX") {
+        if (substr($line, 0, 12)=="CREATE INDEX" && !$config['ignore_index']) {
             preg_match('/CREATE INDEX "?([a-zA-Z0-9_]*)"? ON "?([a-zA-Z0-9_]*)"? USING btree \((.*)\);/', $line, $matches);
             if (isset($matches[1]) && isset($matches[2]) && isset($matches[3])) {
                 $indexname=$matches[1];


### PR DESCRIPTION
I've done some fixes and improvements  :
 - escape all columns name in create table : instead of list reserved keyword for colum name all name are protected in CREATE TABLE
 - support create table inherits : see https://www.postgresql.org/docs/9.1/ddl-inherit.html for more details
 - allow varchar & char to have up to 65000 chars : in the current version char & varchar are converted to text if there size exceed 255, there is no reason to do so
 - add the ability to ignore INDEX : an env variable PG2MYSQL_IGNORE_INDEX could be set to ignore ALTER TABLE ... ADD INDEX