### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 ## Command-Line usage (recommended)
 
-1. `PGPASSWORD=yourpass pg_dump -h localhost --quote-all-identifiers \`
+1. `PGPASSWORD=yourpass pg_dump --rows-per-insert=200 -h localhost --quote-all-identifiers \`
     `--no-acl --no-owner --format p --data-only dbname -f pgfile.sql`
     
     Additional documentation for `pg_dump` [here](http://www.postgresql.org/docs/9.3/static/app-pgdump.html)
     
-1. `php pg2mysql_cli.php pgfile.sql mysqlfile.sql [engine]`
+2. `php pg2mysql_cli.php pgfile.sql mysqlfile.sql [engine]`
     * `pgfile.sql` will not be modified
     * `mysqlfile.sql` will be overwritten if already exists
     * engine is optional, default if not specified is InnoDB


### PR DESCRIPTION
Chunk the pg sql COPY or INSERT statements. 
In the pgfile.sql there will be only 200 lines chunks. This avoids memory issues during the 
`php pg2mysql_cli.php pgfile.sql mysqlfile.sql [engine]` execution